### PR TITLE
Adding nucleo_f7 as a supported board in zephyr apps

### DIFF
--- a/apps/add_two_ints_service/CMakeLists.txt
+++ b/apps/add_two_ints_service/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(COMPATIBLE_BOARDS disco_l475_iot1 olimex_stm32_e407 nucleo_f401re)
+set(COMPATIBLE_BOARDS disco_l475_iot1 olimex_stm32_e407 nucleo_f401re nucleo_f746zg)
 if(NOT ${BOARD} IN_LIST COMPATIBLE_BOARDS)
     message(FATAL_ERROR "App $ENV{UROS_APP} not compatible with board ${BOARD}")
 endif()

--- a/apps/int32_publisher/CMakeLists.txt
+++ b/apps/int32_publisher/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(COMPATIBLE_BOARDS disco_l475_iot1 olimex_stm32_e407 native_posix nucleo_h743zi)
+set(COMPATIBLE_BOARDS disco_l475_iot1 olimex_stm32_e407 native_posix nucleo_h743zi nucleo_f746zg)
 if(NOT ${BOARD} IN_LIST COMPATIBLE_BOARDS)
     message(FATAL_ERROR "App $ENV{UROS_APP} not compatible with board ${BOARD}")
 endif()

--- a/apps/ping_pong/CMakeLists.txt
+++ b/apps/ping_pong/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(COMPATIBLE_BOARDS disco_l475_iot1 olimex_stm32_e407 native_posix nucleo_h743zi)
+set(COMPATIBLE_BOARDS disco_l475_iot1 olimex_stm32_e407 native_posix nucleo_h743zi nucleo_f746zg)
 if(NOT ${BOARD} IN_LIST COMPATIBLE_BOARDS)
     message(FATAL_ERROR "App $ENV{UROS_APP} not compatible with board ${BOARD}")
 endif()


### PR DESCRIPTION
adding support for nucleo_f746zg in zephyr