### PR TITLE
Adjusted CMake paths to use MICROS_ROS_FIRMWARE_DIR

### DIFF
--- a/apps/add_two_ints_service/CMakeLists.txt
+++ b/apps/add_two_ints_service/CMakeLists.txt
@@ -34,8 +34,8 @@ set(external_project_cxxflags
 
 include(ExternalProject)
 
-set(microros_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/../../microros_extensions)
-set(microros_build_dir ${CMAKE_CURRENT_BINARY_DIR}/microros_extensions)
+set(microros_src_dir   ${MICRO_ROS_FIRMWARE_DIR}/zephyr_apps/microros_extensions)
+set(microros_build_dir ${MICRO_ROS_FIRMWARE_DIR}/build/microros_extensions)
 
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
 set(submake "$(MAKE)")
@@ -63,11 +63,11 @@ ExternalProject_Add(
     BUILD_BYPRODUCTS ${MICROROS_LIB_DIR}/libmicroros.a
     )
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
-set(MICROROS_LIB_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-set(MICROROS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+set(MICROROS_LIB_DIR     ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+set(MICROROS_INCLUDE_DIR ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
 add_library(microroslib STATIC IMPORTED GLOBAL)
 add_dependencies(

--- a/apps/attitude_estimator/CMakeLists.txt
+++ b/apps/attitude_estimator/CMakeLists.txt
@@ -36,8 +36,8 @@ set(external_project_cxxflags
 
 include(ExternalProject)
 
-set(microros_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/../../microros_extensions)
-set(microros_build_dir ${CMAKE_CURRENT_BINARY_DIR}/microros_extensions)
+set(microros_src_dir   ${MICRO_ROS_FIRMWARE_DIR}/zephyr_apps/microros_extensions)
+set(microros_build_dir ${MICRO_ROS_FIRMWARE_DIR}/build/microros_extensions)
 
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
 set(submake "$(MAKE)")
@@ -65,11 +65,11 @@ ExternalProject_Add(
     BUILD_BYPRODUCTS ${MICROROS_LIB_DIR}/libmicroros.a
     )
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
-set(MICROROS_LIB_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-set(MICROROS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+set(MICROROS_LIB_DIR     ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+set(MICROROS_INCLUDE_DIR ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
 add_library(microroslib STATIC IMPORTED GLOBAL)
 add_dependencies(

--- a/apps/int32_publisher/CMakeLists.txt
+++ b/apps/int32_publisher/CMakeLists.txt
@@ -34,8 +34,8 @@ set(external_project_cxxflags
 
 include(ExternalProject)
 
-set(microros_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/../../microros_extensions)
-set(microros_build_dir ${CMAKE_CURRENT_BINARY_DIR}/microros_extensions)
+set(microros_src_dir   ${MICRO_ROS_FIRMWARE_DIR}/zephyr_apps/microros_extensions)
+set(microros_build_dir ${MICRO_ROS_FIRMWARE_DIR}/build/microros_extensions)
 
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
 set(submake "$(MAKE)")
@@ -63,11 +63,11 @@ ExternalProject_Add(
     BUILD_BYPRODUCTS ${MICROROS_LIB_DIR}/libmicroros.a
     )
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
-set(MICROROS_LIB_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-set(MICROROS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+set(MICROROS_LIB_DIR     ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+set(MICROROS_INCLUDE_DIR ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
 add_library(microroslib STATIC IMPORTED GLOBAL)
 add_dependencies(

--- a/apps/int32_wifi_publisher/CMakeLists.txt
+++ b/apps/int32_wifi_publisher/CMakeLists.txt
@@ -34,8 +34,8 @@ set(external_project_cxxflags
 
 include(ExternalProject)
 
-set(microros_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/../../microros_extensions)
-set(microros_build_dir ${CMAKE_CURRENT_BINARY_DIR}/microros_extensions)
+set(microros_src_dir   ${MICRO_ROS_FIRMWARE_DIR}/zephyr_apps/microros_extensions)
+set(microros_build_dir ${MICRO_ROS_FIRMWARE_DIR}/build/microros_extensions)
 
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
 set(submake "$(MAKE)")
@@ -63,11 +63,11 @@ ExternalProject_Add(
     BUILD_BYPRODUCTS ${MICROROS_LIB_DIR}/libmicroros.a
     )
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
-set(MICROROS_LIB_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-set(MICROROS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+set(MICROROS_LIB_DIR     ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+set(MICROROS_INCLUDE_DIR ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
 add_library(microroslib STATIC IMPORTED GLOBAL)
 add_dependencies(

--- a/apps/openmanipulator_tof/CMakeLists.txt
+++ b/apps/openmanipulator_tof/CMakeLists.txt
@@ -40,8 +40,8 @@ set(external_project_cxxflags
 
 include(ExternalProject)
 
-set(microros_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/../../microros_extensions)
-set(microros_build_dir ${CMAKE_CURRENT_BINARY_DIR}/microros_extensions)
+set(microros_src_dir   ${MICRO_ROS_FIRMWARE_DIR}/zephyr_apps/microros_extensions)
+set(microros_build_dir ${MICRO_ROS_FIRMWARE_DIR}/build/microros_extensions)
 
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
 set(submake "$(MAKE)")
@@ -69,11 +69,11 @@ ExternalProject_Add(
     BUILD_BYPRODUCTS ${MICROROS_LIB_DIR}/libmicroros.a
     )
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
-set(MICROROS_LIB_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-set(MICROROS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+set(MICROROS_LIB_DIR     ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+set(MICROROS_INCLUDE_DIR ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
 add_library(microroslib STATIC IMPORTED GLOBAL)
 add_dependencies(

--- a/apps/ping_pong/CMakeLists.txt
+++ b/apps/ping_pong/CMakeLists.txt
@@ -34,8 +34,8 @@ set(external_project_cxxflags
 
 include(ExternalProject)
 
-set(microros_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/../../microros_extensions)
-set(microros_build_dir ${CMAKE_CURRENT_BINARY_DIR}/microros_extensions)
+set(microros_src_dir   ${MICRO_ROS_FIRMWARE_DIR}/zephyr_apps/microros_extensions)
+set(microros_build_dir ${MICRO_ROS_FIRMWARE_DIR}/build/microros_extensions)
 
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
 set(submake "$(MAKE)")
@@ -63,11 +63,11 @@ ExternalProject_Add(
     BUILD_BYPRODUCTS ${MICROROS_LIB_DIR}/libmicroros.a
     )
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
-set(MICROROS_LIB_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-set(MICROROS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+set(MICROROS_LIB_DIR     ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+set(MICROROS_INCLUDE_DIR ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
 add_library(microroslib STATIC IMPORTED GLOBAL)
 add_dependencies(

--- a/apps/sensors_publisher/CMakeLists.txt
+++ b/apps/sensors_publisher/CMakeLists.txt
@@ -34,8 +34,8 @@ set(external_project_cxxflags
 
 include(ExternalProject)
 
-set(microros_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/../../microros_extensions)
-set(microros_build_dir ${CMAKE_CURRENT_BINARY_DIR}/microros_extensions)
+set(microros_src_dir   ${MICRO_ROS_FIRMWARE_DIR}/zephyr_apps/microros_extensions)
+set(microros_build_dir ${MICRO_ROS_FIRMWARE_DIR}/build/microros_extensions)
 
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
 set(submake "$(MAKE)")
@@ -63,11 +63,11 @@ ExternalProject_Add(
     BUILD_BYPRODUCTS ${MICROROS_LIB_DIR}/libmicroros.a
     )
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
-set(MICROROS_LIB_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-set(MICROROS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+set(MICROROS_LIB_DIR     ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+set(MICROROS_INCLUDE_DIR ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
 add_library(microroslib STATIC IMPORTED GLOBAL)
 add_dependencies(

--- a/apps/tof_ws2812/CMakeLists.txt
+++ b/apps/tof_ws2812/CMakeLists.txt
@@ -36,8 +36,8 @@ set(external_project_cxxflags
 
 include(ExternalProject)
 
-set(microros_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/../../microros_extensions)
-set(microros_build_dir ${CMAKE_CURRENT_BINARY_DIR}/microros_extensions)
+set(microros_src_dir   ${MICRO_ROS_FIRMWARE_DIR}/zephyr_apps/microros_extensions)
+set(microros_build_dir ${MICRO_ROS_FIRMWARE_DIR}/build/microros_extensions)
 
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
 set(submake "$(MAKE)")
@@ -65,11 +65,11 @@ ExternalProject_Add(
     BUILD_BYPRODUCTS ${MICROROS_LIB_DIR}/libmicroros.a
     )
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
-set(MICROROS_LIB_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-set(MICROROS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+set(MICROROS_LIB_DIR     ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+set(MICROROS_INCLUDE_DIR ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
 add_library(microroslib STATIC IMPORTED GLOBAL)
 add_dependencies(

--- a/apps/vl53l1x_tof_sensor/CMakeLists.txt
+++ b/apps/vl53l1x_tof_sensor/CMakeLists.txt
@@ -40,8 +40,8 @@ set(external_project_cxxflags
 
 include(ExternalProject)
 
-set(microros_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/../../microros_extensions)
-set(microros_build_dir ${CMAKE_CURRENT_BINARY_DIR}/microros_extensions)
+set(microros_src_dir   ${MICRO_ROS_FIRMWARE_DIR}/zephyr_apps/microros_extensions)
+set(microros_build_dir ${MICRO_ROS_FIRMWARE_DIR}/build/microros_extensions)
 
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
 set(submake "$(MAKE)")
@@ -69,11 +69,11 @@ ExternalProject_Add(
     BUILD_BYPRODUCTS ${MICROROS_LIB_DIR}/libmicroros.a
     )
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+file(MAKE_DIRECTORY ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
-set(MICROROS_LIB_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install)
-set(MICROROS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../mcu_ws/install/include)
+set(MICROROS_LIB_DIR     ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install)
+set(MICROROS_INCLUDE_DIR ${MICRO_ROS_FIRMWARE_DIR}/mcu_ws/install/include)
 
 add_library(microroslib STATIC IMPORTED GLOBAL)
 add_dependencies(


### PR DESCRIPTION
This should not change any functionality for the apps, but allow them to
be used as a templates when starting with external custom app folders
(introduced in micro-ROS/micro_ros_setup#183). The currently used
CMAKE_CURRENT_* variables do not work in that scenario and may lead to
confusion when getting started with this feature.