### PR TITLE
Add Blackpill boards to the compatible demos

### DIFF
--- a/apps/add_two_ints_service/CMakeLists.txt
+++ b/apps/add_two_ints_service/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(COMPATIBLE_BOARDS disco_l475_iot1 olimex_stm32_e407 nucleo_f401re nucleo_f746zg)
+set(COMPATIBLE_BOARDS disco_l475_iot1 olimex_stm32_e407 nucleo_f401re nucleo_f746zg blackpill_f411ce blackpill_f401ce)
 if(NOT ${BOARD} IN_LIST COMPATIBLE_BOARDS)
     message(FATAL_ERROR "App $ENV{UROS_APP} not compatible with board ${BOARD}")
 endif()

--- a/apps/int32_publisher/CMakeLists.txt
+++ b/apps/int32_publisher/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(COMPATIBLE_BOARDS disco_l475_iot1 olimex_stm32_e407 native_posix nucleo_h743zi nucleo_f746zg)
+set(COMPATIBLE_BOARDS disco_l475_iot1 olimex_stm32_e407 native_posix nucleo_h743zi nucleo_f746zg blackpill_f411ce blackpill_f401ce)
 if(NOT ${BOARD} IN_LIST COMPATIBLE_BOARDS)
     message(FATAL_ERROR "App $ENV{UROS_APP} not compatible with board ${BOARD}")
 endif()

--- a/apps/ping_pong/CMakeLists.txt
+++ b/apps/ping_pong/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(COMPATIBLE_BOARDS disco_l475_iot1 olimex_stm32_e407 native_posix nucleo_h743zi nucleo_f746zg)
+set(COMPATIBLE_BOARDS disco_l475_iot1 olimex_stm32_e407 native_posix nucleo_h743zi nucleo_f746zg blackpill_f411ce blackpill_f401ce)
 if(NOT ${BOARD} IN_LIST COMPATIBLE_BOARDS)
     message(FATAL_ERROR "App $ENV{UROS_APP} not compatible with board ${BOARD}")
 endif()


### PR DESCRIPTION
This is only to add these popular boards to the demos with compatible transports since the Blackpills support serial and serial-usb. I've tested these demos successfully on ROS Foxy only. Later, I can do the same for ROS Galactic as well.
Signed-off-by: Branilson Luiz <branilson@gmail.com>