### PR TITLE
Adjust default_params initialization for cpp compatibility to avoid - …

### DIFF
--- a/microros_extensions/microros_transports.h
+++ b/microros_extensions/microros_transports.h
@@ -47,7 +47,7 @@ typedef struct {
     static zephyr_transport_params_t default_params = {.fd = 0};
 #elif defined(MICRO_ROS_TRANSPORT_UDP)
     #define MICRO_ROS_FRAMING_REQUIRED false
-    static zephyr_transport_params_t default_params = {.ip = "192.168.1.100", .port = "8888"};
+    static zephyr_transport_params_t default_params = {{0,0,0}, "192.168.1.100", "8888"};
 #elif defined(MICRO_ROS_TRANSPORT_SERIALUSB)
     #define MICRO_ROS_FRAMING_REQUIRED true
     static zephyr_transport_params_t default_params;


### PR DESCRIPTION
…Designator member outside aggregate error, when compiler is cpp.

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/2365134/173125549-0252c0a7-16e4-4884-8275-0220d8d2ec6d.png">
